### PR TITLE
Narrow PartitionsTouchedAfterECTRTool to replace-fileId partitions only

### DIFF
--- a/docs/customer-notes/0.14.0-cleaner-oom-mitigation.md
+++ b/docs/customer-notes/0.14.0-cleaner-oom-mitigation.md
@@ -69,7 +69,7 @@ It adds the following on top of stock 0.14.0:
 | Cleaner / savepoint interplay fix (HUDI-7104) | Fixes an incremental-clean edge case involving savepoints. Prerequisite for the empty-clean support below. |
 | Empty-clean support | New config `hoodie.write.empty.clean.create.duration.ms`. Lets the cleaner emit "empty" clean commits on append-only tables. Those empty commits roll `earliest_commit_to_retain` forward, so the next real clean only has to look at partitions modified after the most recent empty clean. |
 | Partition filter for full clean (apache/hudi PR #17550) | New configs `hoodie.clean.partition.filter.regex` and `hoodie.clean.partition.filter.selected`. Lets you run a one-time full clean scoped to a specific set of partitions instead of the whole table. |
-| `PartitionsTouchedAfterECTRTool` | Standalone Java utility that reads the active timeline and emits the deduplicated list of partitions written or replaced at/after the most recent clean's ECTR. Feeds directly into `hoodie.clean.partition.filter.selected`. |
+| `PartitionsTouchedAfterECTRTool` | Standalone Java utility that reads the active timeline and emits the deduplicated list of partitions whose file IDs were replaced at/after the most recent clean's ECTR. Feeds directly into `hoodie.clean.partition.filter.selected`. |
 
 ## Recovery plan
 
@@ -79,22 +79,25 @@ problem does not recur.
 
 ### Step 1 — one-time targeted clean
 
-Goal: clean only the partitions that actually have garbage — the ones touched
-by `delete_partition` (and any other replace / insert-overwrite) within your
-current active timeline — without scanning the rest of the table.
+Goal: clean only the partitions that actually have garbage — the ones where
+file IDs were replaced by `delete_partition` (or any other replace /
+insert-overwrite / clustering) within your current active timeline — without
+scanning the rest of the table.
 
-1. Build the list of partitions that appear as touched or replaced in the
-   active timeline. The replace-commit and `delete_partition` metadata in the
-   timeline carries this information.
+1. Build the list of partitions where file IDs were replaced in the active
+   timeline. The `replaceCommit` metadata in the timeline carries this
+   information in `partitionToReplaceFileIds`.
 
    The branch ships a standalone tool that does this for you:
    `org.apache.hudi.utilities.PartitionsTouchedAfterECTRTool`. It reads the
    most recent completed clean's `earliestInstantToRetain` (ECTR) from the
-   active timeline and emits the deduplicated set of partitions that were
-   written or replaced at or after that instant. If no completed clean exists
-   (or its plan has no ECTR, e.g. an empty clean), the tool scans the entire
-   active timeline. Only `commit`, `deltaCommit`, and `replaceCommit` instants
-   are considered.
+   active timeline and emits the deduplicated set of partitions whose file IDs
+   were replaced at or after that instant. If no completed clean exists (or
+   its plan has no ECTR, e.g. an empty clean), the tool scans the entire
+   active timeline. Only completed `replaceCommit` instants are considered,
+   and only the partitions in `partitionToReplaceFileIds` — plain `commit` /
+   `deltaCommit` instants and the new-write side of replace commits are
+   ignored because they don't leave any files for the cleaner to reclaim.
 
    Sample invocation:
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/PartitionsTouchedAfterECTRTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/PartitionsTouchedAfterECTRTool.java
@@ -21,7 +21,6 @@ package org.apache.hudi.utilities;
 
 import org.apache.hudi.avro.model.HoodieActionInstant;
 import org.apache.hudi.avro.model.HoodieCleanerPlan;
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -43,20 +42,24 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * Standalone Java tool that lists partitions written or replaced in the active timeline at or
- * after the last known earliest-commit-to-retain (ECTR). The ECTR is sourced from the most
+ * Standalone Java tool that lists partitions whose file IDs were replaced in the active timeline
+ * at or after the last known earliest-commit-to-retain (ECTR). The ECTR is sourced from the most
  * recent completed clean's plan ({@code earliestInstantToRetain}). If no completed clean exists,
  * or that field is null/empty (e.g. the previous clean produced an empty plan), the tool scans
  * the entire active timeline.
  *
- * <p>Only completed {@code commit}, {@code deltaCommit}, and {@code replaceCommit} instants are
- * considered. Other actions (clean, rollback, restore, savepoint, compaction) are ignored
- * because they don't add or replace data partitions in the sense the caller cares about.
+ * <p>Only completed {@code replaceCommit} instants are considered, and only the partitions in
+ * {@code partitionToReplaceFileIds} — i.e. partitions that have file IDs marked for replacement
+ * (insert-overwrite, delete-partition, clustering, etc.). Plain {@code commit} and
+ * {@code deltaCommit} instants, and the new-write side of replace commits, are ignored because
+ * they don't leave any files for the cleaner to reclaim.
  *
  * <p>Sample invocation:
  * <pre>
@@ -115,34 +118,33 @@ public class PartitionsTouchedAfterECTRTool {
     String lowerBound = resolveLowerBound(metaClient);
     LOG.info("Using lower-bound instant timestamp = {} for base path {}", lowerBound, cfg.basePath);
 
-    HoodieTimeline commitsTimeline = metaClient.getActiveTimeline()
-        .getCommitsTimeline()
-        .filterCompletedInstants();
+    HoodieTimeline replaceTimeline = metaClient.getActiveTimeline()
+        .getCompletedReplaceTimeline();
 
-    Set<String> touched = new TreeSet<>();
+    Set<String> replaced = new TreeSet<>();
     long instantCount = 0;
-    for (HoodieInstant instant : commitsTimeline.getInstants()) {
+    for (HoodieInstant instant : replaceTimeline.getInstants()) {
       if (lowerBound != null
           && HoodieTimeline.compareTimestamps(instant.getTimestamp(), HoodieTimeline.LESSER_THAN, lowerBound)) {
         continue;
       }
-      Set<String> partitionsForInstant = partitionsTouchedBy(commitsTimeline, instant);
-      LOG.info("Instant {} (action={}) touched {} partitions",
-          instant.getTimestamp(), instant.getAction(), partitionsForInstant.size());
-      touched.addAll(partitionsForInstant);
+      Set<String> partitionsForInstant = partitionsReplacedBy(replaceTimeline, instant);
+      LOG.info("Replace instant {} replaced file IDs in {} partitions",
+          instant.getTimestamp(), partitionsForInstant.size());
+      replaced.addAll(partitionsForInstant);
       instantCount++;
     }
 
-    LOG.info("Scanned {} completed commit/replace/deltaCommit instants at-or-after {}; total distinct partitions touched = {}",
-        instantCount, lowerBound, touched.size());
-    for (String partition : touched) {
+    LOG.info("Scanned {} completed replaceCommit instants at-or-after {}; total distinct partitions with replaced file IDs = {}",
+        instantCount, lowerBound, replaced.size());
+    for (String partition : replaced) {
       LOG.info("  partition: {}", partition);
     }
 
     if (!StringUtils.isNullOrEmpty(cfg.outputFile)) {
-      writeOutput(touched);
+      writeOutput(replaced);
     }
-    return touched;
+    return replaced;
   }
 
   private String resolveLowerBound(HoodieTableMetaClient metaClient) throws IOException {
@@ -152,7 +154,7 @@ public class PartitionsTouchedAfterECTRTool {
         .lastInstant();
 
     if (!lastClean.isPresent()) {
-      LOG.warn("No completed clean instant found on active timeline; reporting all completed commit/replace partitions");
+      LOG.warn("No completed clean instant found on active timeline; reporting partitions from all completed replaceCommits on the active timeline");
       return null;
     }
 
@@ -170,28 +172,17 @@ public class PartitionsTouchedAfterECTRTool {
     return null;
   }
 
-  private Set<String> partitionsTouchedBy(HoodieTimeline timeline, HoodieInstant instant) {
+  private Set<String> partitionsReplacedBy(HoodieTimeline timeline, HoodieInstant instant) {
     try {
-      switch (instant.getAction()) {
-        case HoodieTimeline.COMMIT_ACTION:
-        case HoodieTimeline.DELTA_COMMIT_ACTION: {
-          HoodieCommitMetadata md = HoodieCommitMetadata.fromBytes(
-              timeline.getInstantDetails(instant).get(), HoodieCommitMetadata.class);
-          return new HashSet<>(md.getPartitionToWriteStats().keySet());
-        }
-        case HoodieTimeline.REPLACE_COMMIT_ACTION: {
-          HoodieReplaceCommitMetadata md = HoodieReplaceCommitMetadata.fromBytes(
-              timeline.getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
-          Set<String> partitions = new HashSet<>();
-          partitions.addAll(md.getPartitionToReplaceFileIds().keySet());
-          partitions.addAll(md.getPartitionToWriteStats().keySet());
-          return partitions;
-        }
-        default:
-          return new HashSet<>();
+      HoodieReplaceCommitMetadata md = HoodieReplaceCommitMetadata.fromBytes(
+          timeline.getInstantDetails(instant).get(), HoodieReplaceCommitMetadata.class);
+      Map<String, List<String>> partitionToReplaceFileIds = md.getPartitionToReplaceFileIds();
+      if (partitionToReplaceFileIds == null || partitionToReplaceFileIds.isEmpty()) {
+        return Collections.emptySet();
       }
+      return new TreeSet<>(partitionToReplaceFileIds.keySet());
     } catch (IOException e) {
-      throw new HoodieIOException("Failed to read commit metadata for instant " + instant, e);
+      throw new HoodieIOException("Failed to read replace commit metadata for instant " + instant, e);
     }
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestPartitionsTouchedAfterECTRTool.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestPartitionsTouchedAfterECTRTool.java
@@ -59,22 +59,24 @@ class TestPartitionsTouchedAfterECTRTool extends HoodieCommonTestHarness {
   }
 
   @Test
-  void noCleanInstant_returnsAllCommitAndReplacePartitions() throws Exception {
+  void noCleanInstant_returnsOnlyPartitionsWithReplacedFileIds() throws Exception {
+    // Plain commits should be ignored — they don't replace any file IDs.
     testTable.addCommit("001", Option.of(commitMetadataFor("p_old_a")));
     testTable.addCommit("002", Option.of(commitMetadataFor("p_old_b")));
+    // For replace commits, only the replaced-fileId side counts; the new-write side does not.
     addReplaceCommit("003", Collections.singleton("p_replaced_x"), Collections.singleton("p_new_x"));
     addDeletePartitionsCommit("004", Collections.singleton("p_deleted_y"));
 
     Set<String> partitions = runTool();
 
-    assertEquals(setOf("p_old_a", "p_old_b", "p_replaced_x", "p_new_x", "p_deleted_y"), partitions);
+    assertEquals(setOf("p_replaced_x", "p_deleted_y"), partitions);
   }
 
   @Test
-  void cleanWithValidEctr_returnsOnlyPartitionsAtOrAfterEctr() throws Exception {
+  void cleanWithValidEctr_returnsOnlyReplacedPartitionsAtOrAfterEctr() throws Exception {
     testTable.addCommit("001", Option.of(commitMetadataFor("p_pre_clean_a")));
     addReplaceCommit("002", Collections.singleton("p_pre_clean_b"), Collections.singleton("p_pre_clean_c"));
-    // Clean records ECTR = "010" => everything at/after 010 should be included.
+    // Clean records ECTR = "010" => only replace-fileId partitions at/after 010 should be included.
     addCleanWithEctr("005", "010");
     testTable.addCommit("011", Option.of(commitMetadataFor("p_post_clean_a")));
     addReplaceCommit("012", Collections.singleton("p_replaced_post"), Collections.singleton("p_new_post"));
@@ -82,13 +84,11 @@ class TestPartitionsTouchedAfterECTRTool extends HoodieCommonTestHarness {
 
     Set<String> partitions = runTool();
 
-    assertEquals(
-        setOf("p_post_clean_a", "p_replaced_post", "p_new_post", "p_deleted_post"),
-        partitions);
+    assertEquals(setOf("p_replaced_post", "p_deleted_post"), partitions);
   }
 
   @Test
-  void cleanWithEmptyEctr_returnsAllCommitAndReplacePartitions() throws Exception {
+  void cleanWithEmptyEctr_returnsAllReplacedPartitions() throws Exception {
     testTable.addCommit("001", Option.of(commitMetadataFor("p_a")));
     addReplaceCommit("002", Collections.singleton("p_replaced"), Collections.singleton("p_new"));
     addDeletePartitionsCommit("003", Collections.singleton("p_deleted"));
@@ -98,21 +98,32 @@ class TestPartitionsTouchedAfterECTRTool extends HoodieCommonTestHarness {
 
     Set<String> partitions = runTool();
 
-    assertEquals(setOf("p_a", "p_replaced", "p_new", "p_deleted"), partitions);
+    assertEquals(setOf("p_replaced", "p_deleted"), partitions);
   }
 
   @Test
-  void instantsStrictlyBeforeEctr_areExcluded() throws Exception {
-    testTable.addCommit("001", Option.of(commitMetadataFor("p_before")));
+  void replaceInstantsStrictlyBeforeEctr_areExcluded() throws Exception {
+    addReplaceCommit("001", Collections.singleton("p_before"), Collections.emptySet());
     addCleanWithEctr("005", "002");
-    testTable.addCommit("002", Option.of(commitMetadataFor("p_at_ectr")));
-    testTable.addCommit("003", Option.of(commitMetadataFor("p_after_ectr")));
+    addReplaceCommit("002", Collections.singleton("p_at_ectr"), Collections.emptySet());
+    addReplaceCommit("003", Collections.singleton("p_after_ectr"), Collections.emptySet());
 
     Set<String> partitions = runTool();
 
     assertTrue(partitions.contains("p_at_ectr"));
     assertTrue(partitions.contains("p_after_ectr"));
     assertEquals(setOf("p_at_ectr", "p_after_ectr"), partitions);
+  }
+
+  @Test
+  void replaceCommitWithNoReplacedFileIds_isIgnored() throws Exception {
+    // Insert-overwrite-table-style or pure-write replace commits with empty replace map shouldn't show up.
+    addReplaceCommit("001", Collections.emptySet(), Collections.singleton("p_new_only"));
+    addReplaceCommit("002", Collections.singleton("p_replaced"), Collections.emptySet());
+
+    Set<String> partitions = runTool();
+
+    assertEquals(setOf("p_replaced"), partitions);
   }
 
   // ----- helpers -----


### PR DESCRIPTION
## Summary

- Narrows `PartitionsTouchedAfterECTRTool` to emit only partitions whose file IDs were *replaced* on a completed `replaceCommit` (`partitionToReplaceFileIds`). Plain `commit` / `deltaCommit` instants and the new-write side of replace commits are no longer scanned.
- Rationale: the tool's output feeds `hoodie.clean.partition.filter.selected`, and the cleaner only has work on partitions where files were replaced. Including bulk-insert / new-write partitions just makes the planner walk extra empty partitions — exactly the OOM shape this branch is meant to avoid on append-only tables.
- Also skips reading `HoodieCommitMetadata` for the plain-commit blobs entirely (uses `getCompletedReplaceTimeline()`), which removes the dominant IO on a bulk-insert pipeline.
- Updates `docs/customer-notes/0.14.0-cleaner-oom-mitigation.md` to match the shipping behavior.

## Test plan

- [x] Unit tests pass: `mvn -pl hudi-utilities test -Dtest=TestPartitionsTouchedAfterECTRTool` → 5/5 (covers no-clean fallback, valid-ECTR boundary, empty-ECTR fallback, strictly-before-ECTR exclusion, and a new test for replace commits with empty `partitionToReplaceFileIds`).
- [x] End-to-end CLI run from the rebuilt `hudi-utilities-bundle` JAR against an on-disk MoR table seeded with 8 plain commits + 4 replace commits + a clean carrying `ECTR=004` + 1 pending (inflight-only) replace. Output matches expected exactly: `p_006, p_009, p_old_a, p_old_b`. Confirms:
  - ECTR resolution from latest completed clean
  - Pre-ECTR replace filtered out
  - Plain commits ignored
  - New-write side of a replace not double-emitted
  - Inflight (non-completed) replace skipped
  - Clean instant not treated as data

🤖 Generated with [Claude Code](https://claude.com/claude-code)